### PR TITLE
Ansible 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ansible role for managing network interfaces on enterprise linux.
 
 * netaddr
 
+**Note**: This role isn't compatible with firewalld
+
 ## Role Variables
 
 * `el_network_interfaces`: List of interfaces

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Configure Enterprise Linux Networking
   license: Apache
 
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
 
   platforms:
     - name: EL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
       enabled: no
     when: ansible_distribution_major_version | version_compare('7', operator='==')
 
-  - include: discovery.yml
+  - import_tasks: discovery.yml
 
   - name: Add/Modify network interfaces
     template:


### PR DESCRIPTION
Small change to support ansible 2.4, which is to use `import_tasks` instead of `include`