### PR TITLE
Move the bond ip4 and gw4 templating out of the bridge conditional.

### DIFF
--- a/templates/bond.j2
+++ b/templates/bond.j2
@@ -14,13 +14,13 @@ OVS_BRIDGE={{ item.bridge }}
 {% else %}
 BRIDGE={{ item.bridge }}
 {% endif %}
+{% endif %}
 {% if item.ip4 is defined %}
 IPADDR={{ item.ip4|ipv4('address') }}
 PREFIX={{ item.ip4|ipv4('prefix') }}
 {% endif %}
 {% if item.gw4 is defined %}
 GATEWAY={{ item.gw4 }}
-{% endif %}
 {% endif %}
 ONBOOT=yes
 BONDING_OPTS="mode={{ item.bonding_mode|default(4)}} lacp_rate={{ item.lacp_rate|default(1) }} xmit_hash_policy={{ item.xmit_hash_policy|default('layer3+4') }} miimon={{ item.miimon|default(100) }}"


### PR DESCRIPTION
This allows configuration of a bond interface with an IP address,
even with no bridge defined.